### PR TITLE
docs: add OctoAcme Project Management README and links (closes #2)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,22 @@
+# OctoAcme Project Management Docs
+
+Welcome to OctoAcme's project management documentation. This README serves as the single entry point for how we plan, execute, and improve projects. It provides a short overview of our process, the main roles involved, our communication cadence, and links to the detailed process documents in this directory.
+
+OctoAcme runs projects through a stage-based lifecycle: Initiation, Planning, Execution & Tracking, Release & Deployment, and Retrospective & Continuous Improvement. Initiation uses a lightweight Project One-pager to clarify the problem, measurable goals, stakeholders, timeline, and risks. Planning turns approved initiatives into prioritized backlog items with acceptance criteria, estimates, and a release plan. Execution follows a predictable delivery workflow with a project board (Backlog → Ready → In Progress → In Review → QA → Done), a disciplined PR process, and regular team rhythms to surface progress and blockers.
+
+Roles and responsibilities are explicit to keep work flowing and reduce single-person dependencies. Project Managers coordinate schedules, risks, and communications; Product Managers define outcomes, prioritize work, and measure success; Developers implement features and tests; QA validates acceptance criteria and critical flows; Stakeholders provide input, review, and approvals. Key artifacts — the Project One-pager, roadmap and release plan, backlog, acceptance criteria, risk register, and retrospective action items — are maintained in the repo as the single sources of truth.
+
+Quality assurance and release discipline are core to our delivery model. Developers include unit and integration tests with changes, CI runs automated tests and security scans, and smoke tests validate critical flows before release. Pre-release gates require passing CI/security scans, completed acceptance criteria, release notes, and a rollback/mitigation plan. After each sprint, release, or incident, retrospectives capture action items with owners and due dates to feed continuous improvement.
+
+## Process Documentation Links
+- [Project Management Overview](docs/octoacme-project-management-overview.md)
+- [Project Initiation Guide](docs/octoacme-project-initiation.md)
+- [Project Planning](docs/octoacme-project-planning.md)
+- [Execution & Tracking](docs/octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](docs/octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](docs/octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](docs/octoacme-retrospective-and-continuous-improvement.md)
+- [Roles & Personas](docs/octoacme-roles-and-personas.md)
+
+## How to use this README
+Keep this README as the entry point for project status and links. Update it if you add or rename process documents so it stays current and discoverable.


### PR DESCRIPTION
Adds docs/README.md with a concise overview of OctoAcme project management processes, roles, communication cadence, QA/release gates, and links to all process docs in docs/