### PR TITLE
docs: improve project management docs — add README, templates, and workflow clarifications (refer #2)

### DIFF
--- a/docs/octoacme-execution-and-tracking.md
+++ b/docs/octoacme-execution-and-tracking.md
@@ -15,6 +15,7 @@ Guidance for managing day-to-day execution and tracking progress toward project 
   - Include issue link and acceptance criteria in PR description
   - Run automated tests and linting in CI before requesting review
   - Require at least one approval before merging (or team-defined policy)
+  - Follow the standardized PR checklist: docs/templates/checklists.md
 
 ## Quality & Testing
 - Unit tests for new logic
@@ -22,6 +23,7 @@ Guidance for managing day-to-day execution and tracking progress toward project 
 - End-to-end smoke tests for critical flows before release
 - Security scanning in CI
 - Manual QA for feature acceptance when needed
+- Refer to the QA checklist for release readiness: docs/templates/checklists.md
 
 ## Reporting & Metrics
 - Track velocity and burndown
@@ -32,6 +34,9 @@ Guidance for managing day-to-day execution and tracking progress toward project 
 - Level 1: Team-level triage in daily standup
 - Level 2: PM escalates to Product Lead and dependent teams
 - Level 3: Sponsor-level escalation for business-impacting issues
+
+## Execution Checklist & Improvements
+To reduce handoffs and ambiguous expectations, the repo now includes standardized templates and checklists (docs/templates/checklists.md) and communication templates (docs/templates/communication-templates.md). Make these part of your PR and release workflows to reduce rework, speed reviews, and improve handoffs.
 
 ## Execution Checklist
 - [ ] Branching and PR conventions documented in repo

--- a/docs/templates/checklists.md
+++ b/docs/templates/checklists.md
@@ -1,0 +1,45 @@
+# OctoAcme — Process Templates & Checklists
+
+This file centralizes lightweight templates and checklists to reduce friction and ensure consistent quality across projects.
+
+## PR Checklist
+Use this checklist in every PR description or as a PR template.
+- [ ] PR links to an issue or project card
+- [ ] Short summary of change and why
+- [ ] Acceptance criteria included (copy from issue)
+- [ ] Tests added / updated for new behavior
+- [ ] CI passes (unit, integration, linting)
+- [ ] Security scans pass (or exceptions documented)
+- [ ] No secrets or sensitive data included
+- [ ] Size is reasonable (split if large) and change is reversible
+- [ ] At least one approver assigned (per team policy)
+
+## QA Checklist (for feature validation)
+- [ ] Acceptance criteria satisfied
+- [ ] Unit tests added/updated
+- [ ] Integration tests added/updated (if applicable)
+- [ ] End-to-end smoke tests for critical flows (pass)
+- [ ] Manual exploratory checks (if needed) documented
+- [ ] Performance/security considerations reviewed
+- [ ] QA sign-off recorded in PR or linked issue
+
+## Release Checklist (pre-deploy)
+- [ ] All PRs merged for release candidate
+- [ ] CI and security scans green
+- [ ] Release notes drafted and reviewed
+- [ ] Rollback / mitigation plan recorded
+- [ ] Smoke tests prepared and owners assigned
+- [ ] Deployment window confirmed (if required)
+- [ ] Post-deploy verification plan (who, when) ready
+- [ ] Stakeholder announcement draft prepared
+
+## Risk Register Template
+Maintain a simple table in the repo or a spreadsheet; add entries as issues if actions are needed.
+
+| ID | Description | Impact (H/M/L) | Likelihood (H/M/L) | Owner | Mitigation | Status |
+|----|-------------|----------------|---------------------|-------|------------|--------|
+| R-001 | Example dependency delay | High | Medium | @owner | Identify fallback vendor | Open |
+
+## How to use
+- Reference these checklists in PR descriptions and release notes.
+- If your team requires stricter rules (e.g., 2 reviewers), document that in the project README.    

--- a/docs/templates/communication-templates.md
+++ b/docs/templates/communication-templates.md
@@ -1,0 +1,36 @@
+# OctoAcme — Communication Templates
+
+This file contains short, copy-pastable templates for regular updates and incidents.
+
+## Weekly Status Template
+Subject: [Project] Weekly Status — <YYYY-MM-DD>
+
+- Progress this week:
+  - <short bullets of completed work>
+- Planned next week:
+  - <short bullets of next steps>
+- Risks & Blockers:
+  - <risk / blocker — owner — mitigation>
+- Decisions / Asks:
+  - <any decisions needed from stakeholders>
+
+Use this template for the weekly stakeholder update or the project README status section.
+
+## Incident Summary Template
+Subject: [Incident] <Short summary> — <YYYY-MM-DD> (Status: <Active/Resolved>)
+
+- Impact: <who/what is affected>
+- Timeline: <what happened and when>
+- Current status: <what is being done>
+- Owner / On-call: <@person>
+- Next update: <time or condition for next update>
+
+After resolution, link to a blameless retrospective and action items.
+
+## Stakeholder Briefing (Milestone)
+Short summary for milestone communications:
+- Milestone name & date
+- High-level outcome & value
+- Risks to note
+- Major decisions requested
+- Next milestone & target date


### PR DESCRIPTION
Summary: Adds docs/README.md as a central entry point, new templates under docs/templates/ (checklists and communication templates), and updates docs/octoacme-execution-and-tracking.md to reference the new templates and checklists. These changes close documentation gaps (PR/QA/release checklists, communication templates, and a single discovery entrypoint) and standardize expectations for PRs, QA, and releases.